### PR TITLE
feat: add http status code check to usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,6 +756,11 @@ public class Main {
                 .build();
 
             CloseableHttpResponse response = client.convert(url, pageProperties, options);
+            
+            var status = response.getStatusLine().getStatusCode();
+            if (status != 200) {
+                throw new RuntimeException("Gotenberg PDF rendering failed with status: " + status);
+            }
 
             // Save the PDF to a file
             var projectDir = Paths.get("").toAbsolutePath().normalize();


### PR DESCRIPTION
Hi!
Thanks for this library!

This PR updates the usage example to include an HTTP status code check before writing the response to a PDF file.

We found this the hard way: an occasional error response from Gotenberg ended up being written to .pdf files, which we only noticed after sent those files to clients.

Hope this helps others avoid the same surprise.
